### PR TITLE
Update platform requirements to iOS 17

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,8 @@ import PackageDescription
 let package = Package(
     name: "Nutrient OCR",
     platforms: [
-        .iOS(.v16),
-        .macCatalyst(.v16),
+        .iOS(.v17),
+        .macCatalyst(.v17),
         .visionOS(.v1)
     ],
     products: [


### PR DESCRIPTION
This updates the required iOS and Mac Catalyst version to iOS 17 as Nutrient iOS SDK 26.9.0 removed support for iOS 16.